### PR TITLE
Pin watson-developer-cloud SDK to prevent breakage.

### DIFF
--- a/notebooks/buildmodels.ipynb
+++ b/notebooks/buildmodels.ipynb
@@ -20,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --upgrade watson_developer_cloud\n",
+    "!pip install watson_developer_cloud==1.5\n",
     "!pip install wget"
    ]
   },


### PR DESCRIPTION
The 2.0 version of Watson python SDK contains breaking changes.
Pin the version for now, and provide fixes in a later patch.